### PR TITLE
Disable default selection on iOS

### DIFF
--- a/Kodi/Artists.swift
+++ b/Kodi/Artists.swift
@@ -70,6 +70,7 @@ extension KodiClient {
     /// Filter the albums for the SwiftUI list
     var artistsFilter: [ArtistFields] {
         let appState = AppState.shared
+        print("Artist filter: \(appState.filter.artists)")
         switch appState.filter.artists {
         case .search:
             return artists.all.filter({self.search.text.isEmpty ? true :

--- a/Kodi/Debug.swift
+++ b/Kodi/Debug.swift
@@ -19,7 +19,7 @@ extension KodiClient {
     ///     - message: String: the message
 
     func log( _ sender: String, _ message: String) {
-        print("\(sender): \(message)")
+        //print("\(sender): \(message)")
         DispatchQueue.main.async {
             if self.debugLog.count > 100 {
                 self.debugLog = []

--- a/Kodi/Songs.swift
+++ b/Kodi/Songs.swift
@@ -87,7 +87,7 @@ extension KodiClient {
     /// Filter the songs for the SwiftUI lists
     var songsFilter: [SongFields] {
         let appState = AppState.shared
-        // print("Song filter: appState: \(appState.filter.songs)")
+        print("Song filter: \(appState.filter.songs)")
         switch appState.filter.songs {
         case .album:
             return songs.all.filter { $0.albumID == appState.selectedAlbum?.albumID }

--- a/Shared/ViewSmartLists.swift
+++ b/Shared/ViewSmartLists.swift
@@ -27,7 +27,11 @@ struct ViewSmartLists: View {
             ViewTabArtistsGenres()
         }
         .onAppear {
-            appState.selectedSmartList = ViewSmartLists.smartMenu.first
+            /// Bug: iOS got upset when doing below. When hiding the sidebar,
+            /// this is triggered on refresh of the UI even thought the sidebar is not visible.
+            if kodi.userInterface == .macOS {
+                appState.selectedSmartList = ViewSmartLists.smartMenu.first
+            }
         }
         .modifier(SmartListsModifier())
     }


### PR DESCRIPTION
Bug: iOS got upset when doing that. When hiding the sidebar, onAppear is triggered on refresh of the UI even thought the sidebar is not visible.